### PR TITLE
Fix Windows timezones.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,8 +133,7 @@ fn from_wide_null(wide: &[u16]) -> OsString {
     use std::os::windows::ffi::OsStringExt;
 
     let len = wide.iter().take_while(|&&c| c != 0).count();
-    let s = OsString::from_wide(&wide[..len]);
-    s
+    OsString::from_wide(&wide[..len])
 }
 
 /// Look for the local timezone using `GetTimeZoneInformation()`
@@ -168,7 +167,7 @@ fn canonize_tz(zone: &str) -> Result<String> {
         return Ok("Europe/Paris".to_string());
     }
     let z = OsStr::new(zone);
-    tz_ok(&z)
+    tz_ok(z)
 }
 
 /// Process the command line


### PR DESCRIPTION
Strings returned by most Win32 syscalls are in fact arrays of UTF16 codepoints and trailing "0000" are not stripped out when converting into `OsString` which messes up string conversions.  In addition, some timezones are using unofficial names, try to work around that.